### PR TITLE
Update mcmod.py

### DIFF
--- a/nonebot_plugin_mcmod/mcmod.py
+++ b/nonebot_plugin_mcmod/mcmod.py
@@ -130,7 +130,7 @@ async def wiki_search(bot: Bot, event: GroupMessageEvent, state: T_State):
                 user_id=bot.self_id,
                 nickname=str(i+1),
                 content=MessageSegment.text(
-                    f'{result[i]['title']}\n{result[i]['link']}'
+                    f'{result[i]["title"]}\n{result[i]["link"]}'
                 )
                 # {result[i]['description']+'\n' if result[i]['description'] else ''}
             ))


### PR DESCRIPTION
防止3.12以下版本的python因为嵌套引号出现“SyntaxError f-string unmatched '['”